### PR TITLE
Fixed Expected nodes disappearing

### DIFF
--- a/pkg/ali/components/NodePool.vue
+++ b/pkg/ali/components/NodePool.vue
@@ -107,7 +107,7 @@ export default defineComponent({
       }
     },
     showDesiredSize() {
-      return this.pool._isNew || !!this.pool.desiredSize;
+      return this.pool._isNew || !(this.pool.minInstances || this.pool.maxInstances);
     }
   },
   watch: {


### PR DESCRIPTION
Fixes #44 
Now, we will display expected node count instead of min and max instances unless those are explicitly present in the config