### PR TITLE
group instance type filters with the search filter

### DIFF
--- a/pkg/ali/components/CruACK.vue
+++ b/pkg/ali/components/CruACK.vue
@@ -801,5 +801,20 @@ export default defineComponent({
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+
+}
+
+.node-pools :deep() .fixed-header-actions {
+  grid-column-gap: 0px;
+
+  .row {
+    justify-content: flex-end;
+  }
+
+  .col {
+    margin-left: 10px;
+    margin-right: 0px;
+  }
+
 }
 </style>


### PR DESCRIPTION
#50 

I updated the inputs to have 10px hardcoded margins, matching the existing search input margin. This is not exactly the same margin rows/cols normally have, but that is based off overall row width, and it'd be tricky (impossible? idk) to get the margin on the search input to match that exactly.


<img width="1562" height="843" alt="Screenshot 2025-11-25 at 2 59 40 PM" src="https://github.com/user-attachments/assets/c66659b4-9a2e-4159-9ac1-a093f8ebfbbd" />
