### PR TITLE
Removed prime check

### DIFF
--- a/pkg/ali/provisioner.ts
+++ b/pkg/ali/provisioner.ts
@@ -3,7 +3,6 @@ import { mapDriver } from '@shell/store/plugins';
 import { isProviderEnabled } from '@shell/utils/settings';
 import type { Component } from 'vue';
 import CruACK from './components/CruACK.vue';
-import { isRancherPrime } from '@shell/config/version';
 export class ACKProvisioner implements IClusterProvisioner {
   static ID = 'alibaba';
 
@@ -36,11 +35,7 @@ export class ACKProvisioner implements IClusterProvisioner {
   }
 
   get hidden(): boolean {
-    return !isProviderEnabled(this.context, this.id) || !isRancherPrime();
-  }
-
-  get prime(): boolean {
-    return true;
+    return !isProviderEnabled(this.context, this.id);
   }
 
   get detailTabs(): any {


### PR DESCRIPTION
The issue with local build was that isPrimeCheck was not reading the actual version information.
However, that made me think if we even need a prime check here: users won't be able to install the extension and the operator on non-prime instances, so it is redundant here